### PR TITLE
Include employees with start date in future.

### DIFF
--- a/Bamboozled/Public/Get-BambooHRDirectory.ps1
+++ b/Bamboozled/Public/Get-BambooHRDirectory.ps1
@@ -62,7 +62,7 @@ function Get-BambooHRDirectory {
     $query = $query -join ''
 
     # API endpoint URL
-    $directoryUrl = "https://api.bamboohr.com/api/gateway.php/{0}/v1/reports/custom?format=json" -f $subDomain
+    $directoryUrl = "https://api.bamboohr.com/api/gateway.php/{0}/v1/reports/custom?format=json&onlyCurrent=false" -f $subDomain
 
     # Build a BambooHR credential object using the provided API key
     $bambooHRAuth = Get-BambooHRAuth -ApiKey $apiKey


### PR DESCRIPTION
G'day Simon,

Thanks for sharing Bamboozled - a neat tool. We're using it to sync employees to AzureAD, but need to do this for employees prior to their start date for system setup etc. I suspect we're not alone in this requirement. I've lazily suggested this is a default rather than parameterising.... if you're ok with this, feel free to merge. Otherwise, feel free to delete the PR!
Cheers, Mark