### PR TITLE
Added onlyCurrent parameter to Get info calls

### DIFF
--- a/Bamboozled/Public/Get-BambooHRDirectory.ps1
+++ b/Bamboozled/Public/Get-BambooHRDirectory.ps1
@@ -9,7 +9,7 @@ function Get-BambooHRDirectory {
         [Parameter(Mandatory=$false,Position=2)]$since,
         [Parameter(Mandatory=$false,Position=3)]$fields,
         [Parameter(Mandatory=$false,Position=4)][switch]$active,
-        [Parameter(Mandatory=$false,Position=5)][bool]$onlyCurrent = $false
+        [Parameter(Mandatory=$false,Position=5)][bool]$onlyCurrent = $true
     )
 
     # Force use of TLS1.2 for compatibility with BambooHR's API server. Powershell on Windows defaults to 1.1, which is unsupported

--- a/Bamboozled/Public/Get-BambooHRDirectory.ps1
+++ b/Bamboozled/Public/Get-BambooHRDirectory.ps1
@@ -8,7 +8,8 @@ function Get-BambooHRDirectory {
         [Parameter(Mandatory=$true,Position=1)]$subDomain,
         [Parameter(Mandatory=$false,Position=2)]$since,
         [Parameter(Mandatory=$false,Position=3)]$fields,
-        [Parameter(Mandatory=$false,Position=4)][switch]$active
+        [Parameter(Mandatory=$false,Position=4)][switch]$active,
+        [Parameter(Mandatory=$false,Position=5)][bool]$onlyCurrent = $false
     )
 
     # Force use of TLS1.2 for compatibility with BambooHR's API server. Powershell on Windows defaults to 1.1, which is unsupported
@@ -63,6 +64,11 @@ function Get-BambooHRDirectory {
 
     # API endpoint URL
     $directoryUrl = "https://api.bamboohr.com/api/gateway.php/{0}/v1/reports/custom?format=json" -f $subDomain
+
+    # Add onlyCurrent URI parameter if requested
+    if (!$onlyCurrent) {
+        $directoryUrl += '&onlyCurrent=false'
+    }
 
     # Build a BambooHR credential object using the provided API key
     $bambooHRAuth = Get-BambooHRAuth -ApiKey $apiKey

--- a/Bamboozled/Public/Get-BambooHRUser.ps1
+++ b/Bamboozled/Public/Get-BambooHRUser.ps1
@@ -8,7 +8,8 @@ function Get-BambooHRUser {
         [Parameter(Mandatory=$true,Position=1)]$subDomain,
         [Parameter(Mandatory=$false,Position=2)]$id,
         [Parameter(Mandatory=$false,Position=3)]$emailAddress,
-        [Parameter(Mandatory=$false,Position=4)]$fields
+        [Parameter(Mandatory=$false,Position=4)]$fields,
+        [Parameter(Mandatory=$false,Position=5)][bool]$onlyCurrent = $true
     )
     # Force use of TLS1.2 for compatibility with BambooHR's API server. Powershell on Windows defaults to 1.1, which is unsupported
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
@@ -40,6 +41,11 @@ function Get-BambooHRUser {
     
     # Define the URL to perform the request to
     $userUrl = 'https://api.bamboohr.com/api/gateway.php/{0}/v1/employees/{1}?fields={2}' -f $subDomain,$employeeID,$fields
+
+    # Add onlyCurrent URI parameter if requested
+    if (!$onlyCurrent) {
+        $userUrl += '&onlyCurrent=false'
+    }
 
     # Build a BambooHR credential object using the provided API key
     $bambooHRAuth = Get-BambooHRAuth -ApiKey $apiKey


### PR DESCRIPTION
Hello,

I saw another active commit on this project which set the _onlyCurrent=false_ URI parameter by default on the URL for Get operations. The problem with that idea is that parameter pulls all future-scheduled changes from sub-tables in employee profiles when defined as false, and there are times when you don't want that (current directory syncs/reports, for example).

For example, if an employee is scheduled to switch departments at the beginning of next month, that change is scheduled in the sub-table, but doesn't hit the main profile until that scheduled date. 
- Not defining **onlyCurrent=false** (or setting **onlyCurrent=true**) will display the information as it currently stands.
- Setting **onlyCurrent=false** will display the most updated data, with that department change.

So I set it as an optional parameter on **Get-BambooHRDirectory** and **Get-BambooHRUser** calls so it can be used in both scenarios (new hire setups AND current directory/user syncs).

Let me know what you think and feel free to modify/pull/delete.

Thanks!